### PR TITLE
Enforce tab title length limits and add tooltips

### DIFF
--- a/static/app/views/issueList/groupSearchViewTabs/editableTabTitle.tsx
+++ b/static/app/views/issueList/groupSearchViewTabs/editableTabTitle.tsx
@@ -4,6 +4,7 @@ import styled from '@emotion/styled';
 
 import {GrowingInput} from 'sentry/components/growingInput';
 import {TabsContext} from 'sentry/components/tabs';
+import {Tooltip} from 'sentry/components/tooltip';
 
 interface EditableTabTitleProps {
   isEditing: boolean;
@@ -101,13 +102,24 @@ function EditableTabTitle({
       onMouseDown={e => {
         e.stopPropagation();
       }}
+      maxLength={128}
     />
   ) : (
-    <div style={{height: '20px'}}>{label}</div>
+    <Tooltip title={label} disabled={label.length <= 50}>
+      <TruncatedText>{label}</TruncatedText>
+    </Tooltip>
   );
 }
 
 export default EditableTabTitle;
+
+const TruncatedText = styled('div')`
+  max-width: 250px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  height: 20px;
+`;
 
 const StyledGrowingInput = styled(GrowingInput)<{
   isEditing: boolean;


### PR DESCRIPTION
<!-- Describe your PR here. -->
Enforces a 128-character limit for tab titles during editing to prevent database errors. For display, titles exceeding 50 characters are now visually truncated with an ellipsis, and the full title is shown in a tooltip on hover, improving user experience and preventing display issues.

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

---
<a href="https://cursor.com/background-agent?bcId=bc-dc7e0f26-0a7d-4226-b51e-d56737dc8e47"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-dc7e0f26-0a7d-4226-b51e-d56737dc8e47"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

